### PR TITLE
Promote from preprod to prod

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -98,9 +98,9 @@ export function newServer(config: Config, authProvider: BlaiseIapNodeProvider, b
     server.post("/api/reports/appointment-resource-planning", auth.Middleware, async function (req: Request, res: Response) {
         console.log("appointment-resource-planning endpoint called");
         const authHeader = await authProvider.getAuthHeader();
-        const { date } = req.body;
+        const { date, survey_tla } = req.body;
         const dateFormatted = dateFormatter(date).format("YYYY-MM-DD");
-        const url = `${config.BertUrl}/api/reports/appointment-resource-planning/${dateFormatted}`;
+        const url = `${config.BertUrl}/api/reports/appointment-resource-planning/${dateFormatted}?survey-tla=${survey_tla}`;
         console.log(url);
         const [status, result] = await SendAPIRequest(logger, req, res, url, "GET", null, authHeader);
         res.status(status).json(result);
@@ -110,9 +110,9 @@ export function newServer(config: Config, authProvider: BlaiseIapNodeProvider, b
     server.post("/api/reports/appointment-resource-planning-summary", auth.Middleware, async function (req: Request, res: Response) {
         console.log("appointment-resource-planning-summary endpoint called");
         const authHeader = await authProvider.getAuthHeader();
-        const { date } = req.body;
+        const { date, survey_tla } = req.body;
         const dateFormatted = dateFormatter(date).format("YYYY-MM-DD");
-        const url = `${config.BertUrl}/api/reports/appointment-resource-planning-summary/${dateFormatted}`;
+        const url = `${config.BertUrl}/api/reports/appointment-resource-planning-summary/${dateFormatted}?survey-tla=${survey_tla}`;
         console.log(url);
         const [status, result] = await SendAPIRequest(logger, req, res, url, "GET", null, authHeader);
         res.status(status).json(result);

--- a/src/components/SurveyDateForm.test.tsx
+++ b/src/components/SurveyDateForm.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import "@testing-library/jest-dom";
+import flushPromises from "../tests/utilities";
+import { createMemoryHistory } from "history";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { Router } from "react-router";
+import SurveyDateForm from "./SurveyDateForm";
+import { act } from "react-dom/test-utils";
+import { screen } from "@testing-library/dom";
+import React from "react";
+import MockDate from "mockdate";
+
+const christmasEve97 = "1997-12-24";
+
+describe("form - survey, date", () => {
+    afterEach(() => {
+        MockDate.reset();
+    });
+
+    beforeEach(() => {
+        MockDate.set(new Date(christmasEve97));
+    });
+
+    it("matches snapshot", async () => {
+        const history = createMemoryHistory();
+        const wrapper = render(
+            <Router history={history}>
+                <SurveyDateForm onSubmitFunction="" />
+            </Router>
+        );
+
+        await act(async () => {
+            await flushPromises();
+        });
+
+        await waitFor(() => {
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+
+    it("renders correctly", async () => {
+        const history = createMemoryHistory();
+        await act(async () => {
+            render(
+                <Router history={history}>
+                    <SurveyDateForm onSubmitFunction="" />
+                </Router>
+            );
+        });
+        expect(screen.queryByText("Select survey")).toBeVisible();
+        expect(screen.queryByText("Show all surveys")).toBeVisible();
+        expect(screen.queryByText("LMS")).toBeVisible();
+        expect(screen.queryByText("Labour Market Survey")).toBeVisible();
+        expect(screen.queryByText("OPN")).toBeVisible();
+        expect(screen.queryByText("Opinions and Lifestyle Survey")).toBeVisible();
+        expect(screen.queryByText("Date")).toBeVisible();
+        expect(screen.queryByText("Run")).toBeVisible();
+
+    });
+    afterAll(() => {
+        cleanup();
+    });
+});

--- a/src/components/SurveyDateForm.tsx
+++ b/src/components/SurveyDateForm.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from "react";
+import { StyledForm } from "blaise-design-system-react-components";
+import dateFormatter from "dayjs";
+
+interface Props {
+    onSubmitFunction: (values: any, setSubmitting: (isSubmitting: boolean) => void) => void;
+}
+
+const SurveyDateForm = ({ onSubmitFunction }: Props): ReactElement => {
+
+    const fields = [
+        {
+            name: "Survey TLA",
+            description: "Select survey",
+            type: "radio",
+            initial_value: "undefined",
+            radioOptions: [
+                { id: "all", value: "undefined", label: "Show all surveys" },
+                { id: "lms", value: "lms", label: "LMS", description: "Labour Market Survey" },
+                { id: "opn", value: "opn", label: "OPN", description: "Opinions and Lifestyle Survey" }
+            ]
+        },
+        {
+            name: "Date",
+            type: "date",
+            initial_value: dateFormatter(new Date()).format("YYYY-MM-DD"),
+        }
+    ];
+
+    return (
+        <>
+            <StyledForm fields={fields} onSubmitFunction={onSubmitFunction} submitLabel={"Run"} />
+        </>
+    );
+};
+
+export default SurveyDateForm;

--- a/src/components/__snapshots__/SurveyDateForm.test.tsx.snap
+++ b/src/components/__snapshots__/SurveyDateForm.test.tsx.snap
@@ -1,0 +1,330 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form - survey, date matches snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        action="#"
+      >
+        <fieldset
+          class="fieldset"
+        >
+          <legend
+            class="fieldset__legend"
+          >
+            Select survey
+          </legend>
+          <div
+            class="radios__items"
+            id="Survey TLA"
+          >
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  checked=""
+                  class="radio__input js-radio"
+                  id="all"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="undefined"
+                />
+                <label
+                  class="radio__label "
+                  for="all"
+                  id="all-label"
+                >
+                  Show all surveys
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="lms"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="lms"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="lms"
+                  id="lms-label"
+                >
+                  LMS
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Labour Market Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="opn"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="opn"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="opn"
+                  id="opn-label"
+                >
+                  OPN
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Opinions and Lifestyle Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
+          </div>
+        </fieldset>
+        <div
+          class="field"
+        >
+          <label
+            class="label "
+            for="Date"
+          >
+            Date
+          </label>
+          <input
+            class="input input--text input-type__input "
+            id="Date"
+            initial_value="1997-12-24"
+            name="Date"
+            type="date"
+            value="1997-12-24"
+          />
+        </div>
+        <br />
+        <button
+          class="btn "
+          data-testid="submit-button"
+          type="submit"
+        >
+          <span
+            class="btn__inner"
+          >
+            Run
+          </span>
+        </button>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      action="#"
+    >
+      <fieldset
+        class="fieldset"
+      >
+        <legend
+          class="fieldset__legend"
+        >
+          Select survey
+        </legend>
+        <div
+          class="radios__items"
+          id="Survey TLA"
+        >
+          <p
+            class="radios__item"
+          >
+            <span
+              class="radio"
+            >
+              <input
+                checked=""
+                class="radio__input js-radio"
+                id="all"
+                initial_value="undefined"
+                name="Survey TLA"
+                type="radio"
+                value="undefined"
+              />
+              <label
+                class="radio__label "
+                for="all"
+                id="all-label"
+              >
+                Show all surveys
+              </label>
+            </span>
+          </p>
+          <br />
+          <p
+            class="radios__item"
+          >
+            <span
+              class="radio"
+            >
+              <input
+                class="radio__input js-radio"
+                id="lms"
+                initial_value="undefined"
+                name="Survey TLA"
+                type="radio"
+                value="lms"
+              />
+              <label
+                class="radio__label label--with-description"
+                for="lms"
+                id="lms-label"
+              >
+                LMS
+                <span
+                  class="label__description radio__label--with-description"
+                  id="white-label-description-hint"
+                >
+                  Labour Market Survey
+                </span>
+              </label>
+            </span>
+          </p>
+          <br />
+          <p
+            class="radios__item"
+          >
+            <span
+              class="radio"
+            >
+              <input
+                class="radio__input js-radio"
+                id="opn"
+                initial_value="undefined"
+                name="Survey TLA"
+                type="radio"
+                value="opn"
+              />
+              <label
+                class="radio__label label--with-description"
+                for="opn"
+                id="opn-label"
+              >
+                OPN
+                <span
+                  class="label__description radio__label--with-description"
+                  id="white-label-description-hint"
+                >
+                  Opinions and Lifestyle Survey
+                </span>
+              </label>
+            </span>
+          </p>
+          <br />
+        </div>
+      </fieldset>
+      <div
+        class="field"
+      >
+        <label
+          class="label "
+          for="Date"
+        >
+          Date
+        </label>
+        <input
+          class="input input--text input-type__input "
+          id="Date"
+          initial_value="1997-12-24"
+          name="Date"
+          type="date"
+          value="1997-12-24"
+        />
+      </div>
+      <br />
+      <button
+        class="btn "
+        data-testid="submit-button"
+        type="submit"
+      >
+        <span
+          class="btn__inner"
+        >
+          Run
+        </span>
+      </button>
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.test.tsx
+++ b/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.test.tsx
@@ -89,6 +89,14 @@ describe("appointment resource planning report with data", () => {
         expect(screen.queryByText("Run appointment resource planning report")).toBeVisible();
         expect(screen.queryByText("Run a Daybatch first to obtain the most accurate results.")).toBeVisible();
         expect(screen.queryByText("Appointments that have already been attempted will not be displayed.")).toBeVisible();
+        
+        expect(screen.queryByText("Select survey")).toBeVisible();
+        expect(screen.queryByText("Show all surveys")).toBeVisible();
+        expect(screen.queryByText("LMS")).toBeVisible();
+        expect(screen.queryByText("Labour Market Survey")).toBeVisible();
+        expect(screen.queryByText("OPN")).toBeVisible();
+        expect(screen.queryByText("Opinions and Lifestyle Survey")).toBeVisible();
+
         expect(screen.queryByText("Date")).toBeVisible();
 
         userEvent.type(screen.getByLabelText(/Date/i), "2021-01-01");
@@ -157,6 +165,14 @@ describe("appointment resource planning report without data", () => {
         expect(screen.queryByText("Run appointment resource planning report")).toBeVisible();
         expect(screen.queryByText("Run a Daybatch first to obtain the most accurate results.")).toBeVisible();
         expect(screen.queryByText("Appointments that have already been attempted will not be displayed.")).toBeVisible();
+        
+        expect(screen.queryByText("Select survey")).toBeVisible();
+        expect(screen.queryByText("Show all surveys")).toBeVisible();
+        expect(screen.queryByText("LMS")).toBeVisible();
+        expect(screen.queryByText("Labour Market Survey")).toBeVisible();
+        expect(screen.queryByText("OPN")).toBeVisible();
+        expect(screen.queryByText("Opinions and Lifestyle Survey")).toBeVisible();
+
         expect(screen.queryByText("Date")).toBeVisible();
 
         userEvent.type(screen.getByLabelText(/Date/i), "2021-01-01");

--- a/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.tsx
+++ b/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.tsx
@@ -10,6 +10,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import ReportErrorPanel from "../../components/ReportErrorPanel";
 import AppointmentSummary from "./AppointmentSummary";
 import { AppointmentResults } from "./AppointmentResults";
+import SurveyDateForm from "../../components/SurveyDateForm";
 
 dateFormatter.extend(utc);
 dateFormatter.extend(timezone);
@@ -30,18 +31,21 @@ function AppointmentResourcePlanning(): ReactElement {
     ];
 
 
-    function runReport(formValues: Record<string, any>, setSubmitting: (isSubmitting: boolean) => void): void {
-        runAppointmentResourcePlanningReport(formValues["date"], setSubmitting);
-        runAppointmentSummary(formValues["date"]);
+    function runReport(form: Record<string, any>, setSubmitting: (isSubmitting: boolean) => void): void {
+        form.survey_tla = form["Survey TLA"];
+        form.date = new Date(form["Date"]);
+
+        runAppointmentResourcePlanningReport(form, setSubmitting);
+        runAppointmentSummary(form);
     }
 
-    function runAppointmentResourcePlanningReport(date: string, setSubmitting: (isSubmitting: boolean) => void): void {
+    function runAppointmentResourcePlanningReport(form: Record<string, any>, setSubmitting: (isSubmitting: boolean) => void): void {
         setMessageNoData("");
         setReportData([]);
         setReportFailed(false);
-        setReportDate(date);
+        setReportDate(form.date);
 
-        getAppointmentResourcePlanningReport(date).then((planningReport: AppointmentResourcePlanningReportData[]) => {
+        getAppointmentResourcePlanningReport(form.date, form.survey_tla).then((planningReport: AppointmentResourcePlanningReportData[]) => {
             if (planningReport.length === 0) {
                 setMessageNoData("No data found for parameters given.");
             }
@@ -57,11 +61,10 @@ function AppointmentResourcePlanning(): ReactElement {
 
     }
 
-    function runAppointmentSummary(date: string): void {
+    function runAppointmentSummary(form: Record<string, any>): void {
         setSummaryData([]);
         setSummaryFailed(false);
-
-        getAppointmentResourcePlanningSummaryReport(date)
+        getAppointmentResourcePlanningSummaryReport(form.date, form.survey_tla)
             .then((summaryReport: AppointmentResourcePlanningSummaryReportData[]) => {
                 console.log(summaryReport);
                 setSummaryData(summaryReport);
@@ -69,14 +72,6 @@ function AppointmentResourcePlanning(): ReactElement {
                 setSummaryFailed(true);
             });
     }
-
-    const fields = [
-        {
-            name: "date",
-            type: "date",
-            initial_value: dateFormatter(new Date()).format("YYYY-MM-DD")
-        }
-    ];
 
     return (
         <>
@@ -94,12 +89,8 @@ function AppointmentResourcePlanning(): ReactElement {
                 </ONSPanel>
 
                 <ReportErrorPanel error={reportFailed} />
-                <div className="u-mt-s">
-                    <StyledForm fields={fields}
-                        onSubmitFunction={runReport}
-                        submitLabel={"Run"} />
-                </div>
-
+                <br/>
+                <SurveyDateForm onSubmitFunction={runReport} />
                 <AppointmentSummary data={summaryData} failed={summaryFailed} />
 
                 <div className=" u-mt-m">

--- a/src/reports/AppointmentResourcePlanning/__snapshots__/AppointmentResourcePlanning.test.tsx.snap
+++ b/src/reports/AppointmentResourcePlanning/__snapshots__/AppointmentResourcePlanning.test.tsx.snap
@@ -59,44 +59,140 @@ Object {
             </p>
           </div>
         </div>
-        <div
-          class="u-mt-s"
+        <br />
+        <form
+          action="#"
         >
-          <form
-            action="#"
+          <fieldset
+            class="fieldset"
           >
+            <legend
+              class="fieldset__legend"
+            >
+              Select survey
+            </legend>
             <div
-              class="field"
+              class="radios__items"
+              id="Survey TLA"
             >
-              <label
-                class="label "
-                for="date"
+              <p
+                class="radios__item"
               >
-                Date
-              </label>
-              <input
-                class="input input--text input-type__input "
-                id="date"
-                initial_value="1997-12-24"
-                name="date"
-                type="date"
-                value="1997-12-24"
-              />
+                <span
+                  class="radio"
+                >
+                  <input
+                    checked=""
+                    class="radio__input js-radio"
+                    id="all"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="undefined"
+                  />
+                  <label
+                    class="radio__label "
+                    for="all"
+                    id="all-label"
+                  >
+                    Show all surveys
+                  </label>
+                </span>
+              </p>
+              <br />
+              <p
+                class="radios__item"
+              >
+                <span
+                  class="radio"
+                >
+                  <input
+                    class="radio__input js-radio"
+                    id="lms"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="lms"
+                  />
+                  <label
+                    class="radio__label label--with-description"
+                    for="lms"
+                    id="lms-label"
+                  >
+                    LMS
+                    <span
+                      class="label__description radio__label--with-description"
+                      id="white-label-description-hint"
+                    >
+                      Labour Market Survey
+                    </span>
+                  </label>
+                </span>
+              </p>
+              <br />
+              <p
+                class="radios__item"
+              >
+                <span
+                  class="radio"
+                >
+                  <input
+                    class="radio__input js-radio"
+                    id="opn"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="opn"
+                  />
+                  <label
+                    class="radio__label label--with-description"
+                    for="opn"
+                    id="opn-label"
+                  >
+                    OPN
+                    <span
+                      class="label__description radio__label--with-description"
+                      id="white-label-description-hint"
+                    >
+                      Opinions and Lifestyle Survey
+                    </span>
+                  </label>
+                </span>
+              </p>
+              <br />
             </div>
-            <br />
-            <button
-              class="btn "
-              data-testid="submit-button"
-              type="submit"
+          </fieldset>
+          <div
+            class="field"
+          >
+            <label
+              class="label "
+              for="Date"
             >
-              <span
-                class="btn__inner"
-              >
-                Run
-              </span>
-            </button>
-          </form>
-        </div>
+              Date
+            </label>
+            <input
+              class="input input--text input-type__input "
+              id="Date"
+              initial_value="1997-12-24"
+              name="Date"
+              type="date"
+              value="1997-12-24"
+            />
+          </div>
+          <br />
+          <button
+            class="btn "
+            data-testid="submit-button"
+            type="submit"
+          >
+            <span
+              class="btn__inner"
+            >
+              Run
+            </span>
+          </button>
+        </form>
         <div
           class=" u-mt-m"
         >
@@ -176,44 +272,140 @@ Object {
           </p>
         </div>
       </div>
-      <div
-        class="u-mt-s"
+      <br />
+      <form
+        action="#"
       >
-        <form
-          action="#"
+        <fieldset
+          class="fieldset"
         >
+          <legend
+            class="fieldset__legend"
+          >
+            Select survey
+          </legend>
           <div
-            class="field"
+            class="radios__items"
+            id="Survey TLA"
           >
-            <label
-              class="label "
-              for="date"
+            <p
+              class="radios__item"
             >
-              Date
-            </label>
-            <input
-              class="input input--text input-type__input "
-              id="date"
-              initial_value="1997-12-24"
-              name="date"
-              type="date"
-              value="1997-12-24"
-            />
+              <span
+                class="radio"
+              >
+                <input
+                  checked=""
+                  class="radio__input js-radio"
+                  id="all"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="undefined"
+                />
+                <label
+                  class="radio__label "
+                  for="all"
+                  id="all-label"
+                >
+                  Show all surveys
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="lms"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="lms"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="lms"
+                  id="lms-label"
+                >
+                  LMS
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Labour Market Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="opn"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="opn"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="opn"
+                  id="opn-label"
+                >
+                  OPN
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Opinions and Lifestyle Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
           </div>
-          <br />
-          <button
-            class="btn "
-            data-testid="submit-button"
-            type="submit"
+        </fieldset>
+        <div
+          class="field"
+        >
+          <label
+            class="label "
+            for="Date"
           >
-            <span
-              class="btn__inner"
-            >
-              Run
-            </span>
-          </button>
-        </form>
-      </div>
+            Date
+          </label>
+          <input
+            class="input input--text input-type__input "
+            id="Date"
+            initial_value="1997-12-24"
+            name="Date"
+            type="date"
+            value="1997-12-24"
+          />
+        </div>
+        <br />
+        <button
+          class="btn "
+          data-testid="submit-button"
+          type="submit"
+        >
+          <span
+            class="btn__inner"
+          >
+            Run
+          </span>
+        </button>
+      </form>
       <div
         class=" u-mt-m"
       >
@@ -350,44 +542,140 @@ Object {
             </p>
           </div>
         </div>
-        <div
-          class="u-mt-s"
+        <br />
+        <form
+          action="#"
         >
-          <form
-            action="#"
+          <fieldset
+            class="fieldset"
           >
+            <legend
+              class="fieldset__legend"
+            >
+              Select survey
+            </legend>
             <div
-              class="field"
+              class="radios__items"
+              id="Survey TLA"
             >
-              <label
-                class="label "
-                for="date"
+              <p
+                class="radios__item"
               >
-                Date
-              </label>
-              <input
-                class="input input--text input-type__input "
-                id="date"
-                initial_value="1997-12-24"
-                name="date"
-                type="date"
-                value="1997-12-24"
-              />
+                <span
+                  class="radio"
+                >
+                  <input
+                    checked=""
+                    class="radio__input js-radio"
+                    id="all"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="undefined"
+                  />
+                  <label
+                    class="radio__label "
+                    for="all"
+                    id="all-label"
+                  >
+                    Show all surveys
+                  </label>
+                </span>
+              </p>
+              <br />
+              <p
+                class="radios__item"
+              >
+                <span
+                  class="radio"
+                >
+                  <input
+                    class="radio__input js-radio"
+                    id="lms"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="lms"
+                  />
+                  <label
+                    class="radio__label label--with-description"
+                    for="lms"
+                    id="lms-label"
+                  >
+                    LMS
+                    <span
+                      class="label__description radio__label--with-description"
+                      id="white-label-description-hint"
+                    >
+                      Labour Market Survey
+                    </span>
+                  </label>
+                </span>
+              </p>
+              <br />
+              <p
+                class="radios__item"
+              >
+                <span
+                  class="radio"
+                >
+                  <input
+                    class="radio__input js-radio"
+                    id="opn"
+                    initial_value="undefined"
+                    name="Survey TLA"
+                    type="radio"
+                    value="opn"
+                  />
+                  <label
+                    class="radio__label label--with-description"
+                    for="opn"
+                    id="opn-label"
+                  >
+                    OPN
+                    <span
+                      class="label__description radio__label--with-description"
+                      id="white-label-description-hint"
+                    >
+                      Opinions and Lifestyle Survey
+                    </span>
+                  </label>
+                </span>
+              </p>
+              <br />
             </div>
-            <br />
-            <button
-              class="btn "
-              data-testid="submit-button"
-              type="submit"
+          </fieldset>
+          <div
+            class="field"
+          >
+            <label
+              class="label "
+              for="Date"
             >
-              <span
-                class="btn__inner"
-              >
-                Run
-              </span>
-            </button>
-          </form>
-        </div>
+              Date
+            </label>
+            <input
+              class="input input--text input-type__input "
+              id="Date"
+              initial_value="1997-12-24"
+              name="Date"
+              type="date"
+              value="1997-12-24"
+            />
+          </div>
+          <br />
+          <button
+            class="btn "
+            data-testid="submit-button"
+            type="submit"
+          >
+            <span
+              class="btn__inner"
+            >
+              Run
+            </span>
+          </button>
+        </form>
         <div
           class=" u-mt-m"
         >
@@ -467,44 +755,140 @@ Object {
           </p>
         </div>
       </div>
-      <div
-        class="u-mt-s"
+      <br />
+      <form
+        action="#"
       >
-        <form
-          action="#"
+        <fieldset
+          class="fieldset"
         >
+          <legend
+            class="fieldset__legend"
+          >
+            Select survey
+          </legend>
           <div
-            class="field"
+            class="radios__items"
+            id="Survey TLA"
           >
-            <label
-              class="label "
-              for="date"
+            <p
+              class="radios__item"
             >
-              Date
-            </label>
-            <input
-              class="input input--text input-type__input "
-              id="date"
-              initial_value="1997-12-24"
-              name="date"
-              type="date"
-              value="1997-12-24"
-            />
+              <span
+                class="radio"
+              >
+                <input
+                  checked=""
+                  class="radio__input js-radio"
+                  id="all"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="undefined"
+                />
+                <label
+                  class="radio__label "
+                  for="all"
+                  id="all-label"
+                >
+                  Show all surveys
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="lms"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="lms"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="lms"
+                  id="lms-label"
+                >
+                  LMS
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Labour Market Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
+            <p
+              class="radios__item"
+            >
+              <span
+                class="radio"
+              >
+                <input
+                  class="radio__input js-radio"
+                  id="opn"
+                  initial_value="undefined"
+                  name="Survey TLA"
+                  type="radio"
+                  value="opn"
+                />
+                <label
+                  class="radio__label label--with-description"
+                  for="opn"
+                  id="opn-label"
+                >
+                  OPN
+                  <span
+                    class="label__description radio__label--with-description"
+                    id="white-label-description-hint"
+                  >
+                    Opinions and Lifestyle Survey
+                  </span>
+                </label>
+              </span>
+            </p>
+            <br />
           </div>
-          <br />
-          <button
-            class="btn "
-            data-testid="submit-button"
-            type="submit"
+        </fieldset>
+        <div
+          class="field"
+        >
+          <label
+            class="label "
+            for="Date"
           >
-            <span
-              class="btn__inner"
-            >
-              Run
-            </span>
-          </button>
-        </form>
-      </div>
+            Date
+          </label>
+          <input
+            class="input input--text input-type__input "
+            id="Date"
+            initial_value="1997-12-24"
+            name="Date"
+            type="date"
+            value="1997-12-24"
+          />
+        </div>
+        <br />
+        <button
+          class="btn "
+          data-testid="submit-button"
+          type="submit"
+        >
+          <span
+            class="btn__inner"
+          >
+            Run
+          </span>
+        </button>
+      </form>
       <div
         class=" u-mt-m"
       >

--- a/src/utilities/HTTP/Reports.ts
+++ b/src/utilities/HTTP/Reports.ts
@@ -64,10 +64,11 @@ async function getInterviewerCallPatternReport(form: Record<string, any>): Promi
     });
 }
 
-async function getAppointmentResourcePlanningReport(date: string): Promise<AppointmentResourcePlanningReportData[]> {
+async function getAppointmentResourcePlanningReport(date: string, survey_tla: string): Promise<AppointmentResourcePlanningReportData[]> {
     const url = "/api/reports/appointment-resource-planning";
     const formData = new FormData();
     formData.append("date", date);
+    formData.append("survey_tla", survey_tla);
 
     return axios.post(url, formData, axiosConfig()).then((response: AxiosResponse) => {
         console.log(`Response: Status ${response.status}, data ${response.data}`);
@@ -81,10 +82,11 @@ async function getAppointmentResourcePlanningReport(date: string): Promise<Appoi
     });
 }
 
-async function getAppointmentResourcePlanningSummaryReport(date: string): Promise<AppointmentResourcePlanningSummaryReportData[]> {
+async function getAppointmentResourcePlanningSummaryReport(date: string, survey_tla: string): Promise<AppointmentResourcePlanningSummaryReportData[]> {
     const url = "/api/reports/appointment-resource-planning-summary";
     const formData = new FormData();
     formData.append("date", date);
+    formData.append("survey_tla", survey_tla);
 
     return axios.post(url, formData, axiosConfig()).then((response: AxiosResponse) => {
         console.log(`Response: Status ${response.status}, data ${response.data}`);

--- a/tests/integration/AppointmentResourcePlanningReport.spec.ts
+++ b/tests/integration/AppointmentResourcePlanningReport.spec.ts
@@ -50,7 +50,7 @@ test.describe("Without data", () => {
             await expect(page.locator("h1")).toHaveText("Run appointment resource planning report");
             await expect(page.locator(".panel--info >> nth=0")).toContainText("Run a Daybatch first to obtain the most accurate results.");
     
-            await page.locator("#date").type("30-06-1990");
+            await page.locator("#Date").type("30-06-1990");
             await page.click("button[type=submit]");
     
             await expect(page.locator(".panel--info >> nth=1")).toHaveText("No data found for parameters given.");
@@ -97,7 +97,7 @@ test.describe("With data", () => {
             await expect(page.locator("h1")).toHaveText("Run appointment resource planning report");
             await expect(page.locator(".panel--info >> nth=0")).toContainText("Run a Daybatch first to obtain the most accurate results.");
 
-            await page.locator("#date").type(`${mirTomorrow()}`);
+            await page.locator("#Date").type(`${mirTomorrow()}`);
             await page.click("button[type=submit]");
 
             // Report items


### PR DESCRIPTION
* WIP: Add frontend and pass correct variables

Implemented form to filter by survey TLA and passed through to backend (BERT)

Reviewed by: Cal, El, Jamie
Refs: BLAIS5-3060

* feature: Allow filtering of Appointment Resource Planning Report

Add functionality to allow user to filter report by Survey TLA

Reviewed by: Cal, Jamie

Refs: BLAIS5-3060

* update snapshots

* refactor: add break to appoinment resource planning report

currently there is no gap between the survey radio buttons and the panel

reviewed-by: James, Jamie & El
refs: BLAIS5-3060

* refactor: update snapshots

reviewed-by: James, Jamie & El
refs: BLAIS5-3060

* fixed issue where ID of the date picker had changed (#109)

* fml (#110)

* Revert "fml (#110)" (#111)

This reverts commit 5561046c07fe7a34b5eeb75ddb13a790927defdd.

Co-authored-by: calnic <98323072+cal-nic@users.noreply.github.com>
Co-authored-by: James Anthony Williams <81305008+JAWilliamsONS@users.noreply.github.com>
Co-authored-by: Jamie Kerr <60973239+jamiestephenkerr@users.noreply.github.com>