### PR TITLE
BLAIS5-3118 HTTP Error Handling

### DIFF
--- a/src/reports/filters/InstrumentFilter.test.tsx
+++ b/src/reports/filters/InstrumentFilter.test.tsx
@@ -124,6 +124,14 @@ describe("the interviewer details page renders correctly", () => {
         });
     });
 
+    it("displays an error when non-500 is returned", async () => {
+        mockAdapter.onPost("/api/instruments").reply(500, []);
+        renderComponent();
+        await waitFor(() => {
+            screen.getByText("An error occurred when trying to the list of questionnaires");
+        });
+    });
+
     it("checks all provided instruments by default", async () => {
         mockAdapter.onPost("/api/instruments").reply(200, instrumentDataReturned);
         renderComponent();

--- a/src/reports/filters/InstrumentFilter.test.tsx
+++ b/src/reports/filters/InstrumentFilter.test.tsx
@@ -124,8 +124,16 @@ describe("the interviewer details page renders correctly", () => {
         });
     });
 
-    it("displays an error when non-500 is returned", async () => {
+    it("displays an error when an error HTTP status is returned", async () => {
         mockAdapter.onPost("/api/instruments").reply(500, []);
+        renderComponent();
+        await waitFor(() => {
+            screen.getByText("An error occurred when trying to the list of questionnaires");
+        });
+    });
+
+    it("displays an error when a non-200 success HTTP status is returned", async () => {
+        mockAdapter.onPost("/api/instruments").reply(201, instrumentDataReturned);
         renderComponent();
         await waitFor(() => {
             screen.getByText("An error occurred when trying to the list of questionnaires");

--- a/src/reports/filters/InstrumentFilter.test.tsx
+++ b/src/reports/filters/InstrumentFilter.test.tsx
@@ -128,7 +128,7 @@ describe("the interviewer details page renders correctly", () => {
         mockAdapter.onPost("/api/instruments").reply(500, []);
         renderComponent();
         await waitFor(() => {
-            screen.getByText("An error occurred when trying to the list of questionnaires");
+            screen.getByText("An error occurred while fetching the list of questionnaires");
         });
     });
 
@@ -136,7 +136,7 @@ describe("the interviewer details page renders correctly", () => {
         mockAdapter.onPost("/api/instruments").reply(201, instrumentDataReturned);
         renderComponent();
         await waitFor(() => {
-            screen.getByText("An error occurred when trying to the list of questionnaires");
+            screen.getByText("An error occurred while fetching the list of questionnaires");
         });
     });
 

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -29,10 +29,24 @@ function axiosConfig(): AxiosRequestConfig {
     };
 }
 
+function FetchInstrumentsError() {
+    return (
+        <div role="alert">
+            <ONSPanel status="error">
+                <h2>An error occurred when trying to the list of questionnaires</h2>
+                <p>Try again later.</p>
+                <p>If you are still experiencing problems <a href="https://ons.service-now.com/">report this
+                    issue</a> to Service Desk</p>
+            </ONSPanel>
+        </div>
+    );
+}
+
 function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
     const [messageNoData, setMessageNoData] = useState<string>("");
     const [fields, setFields] = useState<FormFieldObject[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingFailed, setIsLoadingFailed] = useState(false);
     const [numberOfInstruments, setNumberOfInstruments] = useState(0);
     const {
         interviewer,
@@ -47,7 +61,12 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
 
 
     useEffect(() => {
-            getInstrumentList().then(setupForm);
+            getInstrumentList()
+                .then(setupForm)
+                .catch((error: Error) => {
+                    setIsLoadingFailed(true);
+                    console.error(`Response: Error ${error}`);
+                });
         }, []
     );
 
@@ -88,9 +107,6 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
                 return response.data;
             }
             throw ("Response was not 200");
-        }).catch((error: Error) => {
-            console.error(`Response: Error ${error}`);
-            throw error;
         });
     }
 
@@ -100,6 +116,9 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
     }
 
     function displayCheckboxes() {
+        if (isLoadingFailed) {
+            return <FetchInstrumentsError/>;
+        }
         if (isLoading) {
             return <ONSLoadingPanel/>;
         }

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -107,6 +107,7 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
             if (response.status === 200) {
                 return response.data;
             }
+
             throw ("Response was not 200");
         });
     }

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -1,7 +1,7 @@
 import React, {ReactElement, useEffect, useState, Fragment} from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import dateFormatter from "dayjs";
-import axios, {AxiosRequestConfig, AxiosResponse} from "axios";
+import axios, {AxiosRequestConfig} from "axios";
 import {AuthManager} from "blaise-login-react-client";
 import {
     FormFieldObject,
@@ -33,7 +33,7 @@ function FetchInstrumentsError() {
     return (
         <div role="alert">
             <ONSPanel status="error">
-                <h2>An error occurred when trying to the list of questionnaires</h2>
+                <h2>An error occurred while fetching the list of questionnaires</h2>
                 <p>Try again later.</p>
                 <p>If you are still experiencing problems <a href="https://ons.service-now.com/">report this
                     issue</a> to Service Desk</p>

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -42,11 +42,12 @@ function FetchInstrumentsError() {
     );
 }
 
+type Status = "loading" | "loaded" | "loading_failed"
+
 function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
     const [messageNoData, setMessageNoData] = useState<string>("");
+    const [status, setStatus] = useState<Status>("loading");
     const [fields, setFields] = useState<FormFieldObject[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [isLoadingFailed, setIsLoadingFailed] = useState(false);
     const [numberOfInstruments, setNumberOfInstruments] = useState(0);
     const {
         interviewer,
@@ -64,7 +65,7 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
             getInstrumentList()
                 .then(setupForm)
                 .catch((error: Error) => {
-                    setIsLoadingFailed(true);
+                    setStatus("loading_failed");
                     console.error(`Response: Error ${error}`);
                 });
         }, []
@@ -84,7 +85,7 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
             },
         ]);
         setNumberOfInstruments(allInstruments.length);
-        setIsLoading(false);
+        setStatus("loaded");
     }
 
     async function getInstrumentList(): Promise<string[]> {
@@ -116,10 +117,10 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
     }
 
     function displayCheckboxes() {
-        if (isLoadingFailed) {
+        if (status === "loading_failed") {
             return <FetchInstrumentsError/>;
         }
-        if (isLoading) {
+        if (status === "loading") {
             return <ONSLoadingPanel/>;
         }
         if (numberOfInstruments === 0) {


### PR DESCRIPTION
**WAIT UNTIL https://github.com/ONSdigital/blaise-management-information-reports/pull/124 IS MERGED BEFORE REVIEWING**

Add error handling to the InstrumentFilter.

- fix: Add error handling for HTTP error
- refactor: Use status instead of multiple bools
- test: Add test for non-200 response
- refactor: Extract questionnaire fetching logic

### Screenshot
![Screenshot 2022-05-25 at 09 43 13](https://user-images.githubusercontent.com/1959183/170221057-2202f003-d624-4611-9c39-b9483978e5f2.png)