### PR TITLE
BLAIS5-3118 Error when no questionnaire is selected

### DIFF
--- a/src/reports/filters/InstrumentFilter.test.tsx
+++ b/src/reports/filters/InstrumentFilter.test.tsx
@@ -162,6 +162,20 @@ describe("the interviewer details page renders correctly", () => {
         expect(submit).toHaveBeenCalled();
     });
 
+    it("displays an error when submitting with no checkboxes selected", async () => {
+        mockAdapter.onPost("/api/instruments").reply(200, instrumentDataReturned);
+        renderComponent();
+        await act(async () => {
+            fireEvent.click(await screen.findByText(/LMS2101_AA1/));
+            fireEvent.click(await screen.findByText(/Run report/));
+        });
+        const elements = await screen.findAllByText("At least one questionnaire must be selected");
+        expect(elements[0]).toBeVisible();
+        expect(elements[1]).toBeVisible();
+        expect(setInstruments).not.toHaveBeenCalled();
+        expect(submit).not.toHaveBeenCalled();
+    });
+
     afterAll(() => {
         cleanup();
     });

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -110,6 +110,7 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
                 name: "questionnaires",
                 type: "checkbox",
                 initial_value: instruments,
+                validate: (values: string[]) => values.length > 0 ? undefined : "At least one questionnaire must be selected",
                 checkboxOptions: allInstruments.map(name => ({
                     id: name,
                     value: name,


### PR DESCRIPTION
**WAIT UNTIL https://github.com/ONSdigital/blaise-management-information-reports/pull/124 IS MERGED BEFORE REVIEWING**

Display an error message when no questionnaires are selected.

- fix: Display error message when no questionnaires are selected

### Screenshot
![Screenshot 2022-05-25 at 10 44 41](https://user-images.githubusercontent.com/1959183/170235118-61dca53e-b811-4693-a6af-210d46ed0801.png)
