### PR TITLE
BLAIS5-3131 Remove duplicate questionnaire not found message

### DIFF
--- a/src/reports/filters/InstrumentFilter.test.tsx
+++ b/src/reports/filters/InstrumentFilter.test.tsx
@@ -119,7 +119,6 @@ describe("the interviewer details page renders correctly", () => {
         mockAdapter.onPost("/api/instruments").reply(200, []);
         renderComponent();
         await waitFor(() => {
-            screen.getByText("No data found for parameters given.");
             screen.getByText("No questionnaires found for given parameters.");
         });
     });

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -1,12 +1,7 @@
-import React, {ReactElement, useEffect, useState, Fragment} from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import dateFormatter from "dayjs";
-import {
-    FormFieldObject,
-    ONSLoadingPanel,
-    ONSPanel,
-    StyledForm
-} from "blaise-design-system-react-components";
+import { FormFieldObject, ONSLoadingPanel, ONSPanel, StyledForm } from "blaise-design-system-react-components";
 import CallHistoryLastUpdatedStatus from "../../components/CallHistoryLastUpdatedStatus";
 import { getInstrumentList } from "../../utilities/HTTP";
 
@@ -37,7 +32,6 @@ function FetchInstrumentsError() {
 type Status = "loading" | "loaded" | "loading_failed"
 
 function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
-    const [messageNoData, setMessageNoData] = useState<string>("");
     const [status, setStatus] = useState<Status>("loading");
     const [fields, setFields] = useState<FormFieldObject[]>([]);
     const [numberOfInstruments, setNumberOfInstruments] = useState(0);
@@ -55,14 +49,8 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
 
     useEffect(() => {
         async function fetchInstruments(): Promise<string[]> {
-            const instruments = await getInstrumentList(surveyTla, interviewer, startDate, endDate);
-            if (instruments.length === 0) {
-                setMessageNoData("No data found for parameters given.");
-            }
-            return instruments;
+            return getInstrumentList(surveyTla, interviewer, startDate, endDate);
         }
-
-        setMessageNoData("");
 
         fetchInstruments()
             .then(setupForm)
@@ -136,8 +124,6 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
                         </div>
                     </div>
                 </main>
-
-                <ONSPanel hidden={messageNoData === "" && true}>{messageNoData}</ONSPanel>
             </div>
         </>
     );

--- a/src/reports/filters/InstrumentFilter.tsx
+++ b/src/reports/filters/InstrumentFilter.tsx
@@ -107,10 +107,6 @@ function InstrumentFilter(props: InstrumentFilterPageProps): ReactElement {
                     }]}/>
 
                 <main id="main-content" className="page__main u-mt-s">
-                    {/*<h1 className="u-mb-m">Select questionnaires for <em className="highlight">{interviewer}</em>,*/}
-                    {/*    between <em className="highlight">{dateFormatter(startDate).format("DD/MM/YYYY")}</em> and <em*/}
-                    {/*        className="highlight">{dateFormatter(endDate).format("DD/MM/YYYY")}</em>*/}
-                    {/*</h1>*/}
                     <h1>Select questionnaires for</h1>
                     <h3 className="u-mb-m">
                         Interviewer: {interviewer}<br></br>

--- a/src/reports/filters/__snapshots__/InstrumentFilter.test.tsx.snap
+++ b/src/reports/filters/__snapshots__/InstrumentFilter.test.tsx.snap
@@ -189,14 +189,6 @@ Object {
             </div>
           </div>
         </main>
-        <div
-          class="panel panel--info panel--no-title  u-mt-m"
-          hidden=""
-        >
-          <div
-            class="panel__body "
-          />
-        </div>
       </div>
     </div>
   </body>,
@@ -385,14 +377,6 @@ Object {
           </div>
         </div>
       </main>
-      <div
-        class="panel panel--info panel--no-title  u-mt-m"
-        hidden=""
-      >
-        <div
-          class="panel__body "
-        />
-      </div>
     </div>
   </div>,
   "debug": [Function],
@@ -651,14 +635,6 @@ Object {
             </div>
           </div>
         </main>
-        <div
-          class="panel panel--info panel--no-title  u-mt-m"
-          hidden=""
-        >
-          <div
-            class="panel__body "
-          />
-        </div>
       </div>
     </div>
   </body>,
@@ -860,14 +836,6 @@ Object {
           </div>
         </div>
       </main>
-      <div
-        class="panel panel--info panel--no-title  u-mt-m"
-        hidden=""
-      >
-        <div
-          class="panel__body "
-        />
-      </div>
     </div>
   </div>,
   "debug": [Function],


### PR DESCRIPTION
Choose Interviews Call History, enter a search which will return no questionnaires, confirm that only one message is show.

- fix: Remove duplicate message
- chore: Remove unnecessary import

![image](https://user-images.githubusercontent.com/1959183/170277438-e894eab6-b49b-4eeb-bfdb-299e165bec1a.png)
