### PR TITLE
Blais5 3121 lint fix warnings

### DIFF
--- a/server/Server.test.ts
+++ b/server/Server.test.ts
@@ -43,13 +43,13 @@ const mockAuth: Auth = {
         Roles: [],
         BlaiseApiUrl: ""
     },
-    SignToken: function (user: User): string {
+    SignToken: function (): string {
         throw new Error("Function not implemented.");
     },
-    ValidateToken: function (token: string): boolean {
+    ValidateToken: function (): boolean {
         throw new Error("Function not implemented.");
     },
-    UserHasRole: function (user: User): boolean {
+    UserHasRole: function (): boolean {
         throw new Error("Function not implemented.");
     },
     Middleware: async function (request: Request, response: Response, next: NextFunction): Promise<void | Response> {

--- a/server/Server.test.ts
+++ b/server/Server.test.ts
@@ -2,7 +2,7 @@ import { newServer } from "./Server";
 import supertest from "supertest";
 import { Config } from "./Config";
 import BlaiseIapNodeProvider from "blaise-iap-node-provider";
-import BlaiseApiClient, { User } from "blaise-api-node-client";
+import BlaiseApiClient from "blaise-api-node-client";
 import { Auth } from "blaise-login-react-server";
 import { Request, Response, NextFunction } from "express";
 import axios from "axios";

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -155,7 +155,7 @@ export function newServer(config: Config, authProvider: BlaiseIapNodeProvider, a
         res.render("index.html");
     });
 
-    server.use(function (err: Error, req: Request, res: Response, next: NextFunction) {
+    server.use(function (err: Error, req: Request, res: Response) {
         logger(req, res);
         req.log.error(err, err.message);
         res.render("../../views/500.html", {});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import "./style.css";
 import { LoginForm, AuthManager } from "blaise-login-react-client";
 import InterviewerCallHistory from "./reports/InterviewerCallHistory/InterviewerCallHistory";
 import ReportDetails from "./components/ReportDetails";
-import AppointmentResourcePlanningSteps from "./reports/AppointmentResourcePlanning/AppointmentResourcePlanning";
 
 const divStyle = {
     minHeight: "calc(72vh)"

--- a/src/features/step_definitions/run_and_view_appointment_resource_planning_report.test.tsx
+++ b/src/features/step_definitions/run_and_view_appointment_resource_planning_report.test.tsx
@@ -119,7 +119,7 @@ defineFeature(feature, test => {
             });
         });
 
-        then("I will receive a list of the following information for appointments made:", async (docString) => {
+        then("I will receive a list of the following information for appointments made:", async () => {
             await waitFor(() => {
                 expect(screen.getByText("Questionnaire")).toBeInTheDocument();
                 expect(screen.getByText("Appointment Time")).toBeInTheDocument();
@@ -132,7 +132,7 @@ defineFeature(feature, test => {
             });
         });
 
-        and("the information will be displayed in time intervals of quarter of an hour, e.g. 09:00, 09:15, 09:30, 09:45, 10:00, 10:15, etc.", async (docString) => {
+        and("the information will be displayed in time intervals of quarter of an hour, e.g. 09:00, 09:15, 09:30, 09:45, 10:00, 10:15, etc.", async () => {
             expect(screen.getByText("10:00")).toBeInTheDocument();
         });
     });

--- a/src/features/step_definitions/run_and_view_interviewer_call_history_report.test.tsx
+++ b/src/features/step_definitions/run_and_view_interviewer_call_history_report.test.tsx
@@ -97,7 +97,7 @@ defineFeature(feature, test => {
 
         });
 
-        then("I will receive a list of the following information relating to that interviewer for each call worked on, during the time period specified:", async (docString) => {
+        then("I will receive a list of the following information relating to that interviewer for each call worked on, during the time period specified:", async () => {
             await waitFor(() => {
                 expect(screen.findAllByText(/LMS2101_AA1/)).toBeDefined();
                 expect(screen.getByText(/1337/)).toBeInTheDocument();

--- a/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.test.tsx
+++ b/src/reports/AppointmentResourcePlanning/AppointmentResourcePlanning.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { AppointmentResourcePlanningReportData } from "../../interfaces";
 import "@testing-library/jest-dom";
 import flushPromises from "../../tests/utilities";
 import { createMemoryHistory } from "history";
@@ -18,35 +17,6 @@ import axios from "axios";
 import userEvent from "@testing-library/user-event";
 
 const mockAdapter = new MockAdapter(axios);
-
-const ReportSummary = [
-    { language: "English", total: 1 },
-    { language: "Welsh", total: 1 },
-    { language: "Other", total: 1 },
-];
-
-const reportDataReturned: AppointmentResourcePlanningReportData[] = [
-    {
-        questionnaire_name: "LMS2101_AA1",
-        appointment_time: "10:00",
-        appointment_language: "English",
-        total: 42
-    },
-    {
-        questionnaire_name: "LMS2101_BB1",
-        appointment_time: "12:30",
-        appointment_language: "Welsh",
-        total: 1908
-    },
-    {
-        questionnaire_name: "LMS2101_CC1",
-        appointment_time: "15:15",
-        appointment_language: "Other",
-        total: 408
-    }
-];
-
-const questionnairesReturned = ["LMS2101_AA1", "LMS2101_BB1", "LMS2101_CC1"];
 
 const christmasEve97 = "1997-12-24";
 

--- a/src/reports/AppointmentResourcePlanning/RenderAppointmentResourcePlanningReport.tsx
+++ b/src/reports/AppointmentResourcePlanning/RenderAppointmentResourcePlanningReport.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import { CSVLink } from "react-csv";
 import { AppointmentResourcePlanningReportData, AppointmentResourcePlanningSummaryReportData } from "../../interfaces";
@@ -24,7 +24,7 @@ function formatList(listOfQuestionnaires: string[]): string {
     return firsts.join(", ") + " and " + last;
 }
 
-function RenderAppointmentResourcePlanningReport(props: RenderAppointmentResourcePlanningReportPageProps) {
+function RenderAppointmentResourcePlanningReport(props: RenderAppointmentResourcePlanningReportPageProps): ReactElement {
     const [reportFailed, setReportFailed] = useState<boolean>(false);
     const [reportData, setReportData] = useState<AppointmentResourcePlanningReportData[]>([]);
     const [messageNoData, setMessageNoData] = useState<string>("");

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -24,10 +24,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
     const [interviewerID, setInterviewerID] = useState<string>("");
     const [messageNoData, setMessageNoData] = useState<string>("");
     const {
-        interviewer,
-        startDate,
-        endDate,
-        questionnaires,
         navigateBack,
         navigateBackTwoSteps,
     } = props;

--- a/src/reports/filters/QuestionnaireFilter.tsx
+++ b/src/reports/filters/QuestionnaireFilter.tsx
@@ -17,9 +17,6 @@ interface QuestionnaireFilterPageProps {
 
 function QuestionnaireFilter(props: QuestionnaireFilterPageProps): ReactElement {
     const {
-        interviewer,
-        startDate,
-        endDate,
         navigateBack,
     } = props;
 

--- a/tests/integration/AppointmentResourcePlanningReport.spec.ts
+++ b/tests/integration/AppointmentResourcePlanningReport.spec.ts
@@ -1,16 +1,16 @@
 import { expect, test } from "@playwright/test";
-import BlaiseApiClient, { NewUser } from "blaise-api-node-client";
-import { deleteTestUser, setupQuestionnaire, setupTestUser, unInstallQuestionnaire, } from "./helpers/BlaiseHelpers";
-import { setupAppointment, clearCATIData } from "./helpers/CatiHelpers";
-import { loginMIR, mirTomorrow } from "./helpers/MirHelpers";
+// import BlaiseApiClient, { NewUser } from "blaise-api-node-client";
+// import { deleteTestUser, setupQuestionnaire, setupTestUser, unInstallQuestionnaire, } from "./helpers/BlaiseHelpers";
+// import { setupAppointment, clearCATIData } from "./helpers/CatiHelpers";
+// import { loginMIR, mirTomorrow } from "./helpers/MirHelpers";
 
-const restApiUrl = process.env.REST_API_URL || "http://localhost:8000";
-const restApiClientId = process.env.REST_API_CLIENT_ID || undefined;
-const questionnaireName = process.env.TEST_QUESTIONNAIRE;
-const serverPark = process.env.SERVER_PARK;
-const blaiseApiClient = new BlaiseApiClient(restApiUrl, { blaiseApiClientId: restApiClientId });
+// const restApiUrl = process.env.REST_API_URL || "http://localhost:8000";
+// const restApiClientId = process.env.REST_API_CLIENT_ID || undefined;
+// const questionnaireName = process.env.TEST_QUESTIONNAIRE;
+// const serverPark = process.env.SERVER_PARK;
+// const blaiseApiClient = new BlaiseApiClient(restApiUrl, { blaiseApiClientId: restApiClientId });
 
-let userCredentials: NewUser;
+// let userCredentials: NewUser;
 
 // if (!questionnaireName) {
 //     console.error("Questionnaire name is undefined");


### PR DESCRIPTION
This PR fixes 31 of 52 lint warnings.

Of the remaining 21 warnings there are 2 types:
* Warnings in RenderInterviewerCallPatternReport.tsx which I'm hoping to address in a separate branch
* @typescript-eslint/no-explicit-any warnings which require special attention some other time :eyes: