### PR TITLE
test: Increase Jest timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ process.env = Object.assign(process.env, {
 });
 
 module.exports = {
+    testTimeout: 10000,
     moduleNameMapper: {
         "\\.(css|less|scss)$": "identity-obj-proxy",
         "\\.(jpg)$": "identity-obj-proxy"


### PR DESCRIPTION
Concourse is currently failing with timeouts fairly often for the Gherkin tests. Since Concourse seems to be slow at the moment, I'm just experimenting with extending the timeout to stop the failures.

Refs: BLAIS5-3365
