### PR TITLE
BLAIS5-3387: Add test for RenderInterviewerCallHistoryReport and fix error reporting and spinner

### DIFF
--- a/src/components/CallHistoryReportTable.tsx
+++ b/src/components/CallHistoryReportTable.tsx
@@ -42,9 +42,9 @@ export default function callHistoryReportTable({ reportData, messageNoData }: Ca
                 </thead>
                 <tbody className="table__body">
                     {
-                        reportData.map((callHistory: InterviewerCallHistoryReport) => {
+                        reportData.map((callHistory: InterviewerCallHistoryReport, index: number) => {
                             return (
-                                <tr className="table__row" key={callHistory.call_start_time}
+                                <tr className="table__row" key={index}
                                     data-testid={"report-table-row"}>
                                     <td className="table__cell ">
                                         {callHistory.questionnaire_name}

--- a/src/components/FilterSummary.test.tsx
+++ b/src/components/FilterSummary.test.tsx
@@ -1,60 +1,55 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { createMemoryHistory } from "history";
-import { render, RenderResult } from "@testing-library/react";
-import { Router } from "react-router";
+import { render, screen } from "@testing-library/react";
 import FilterSummary from "./FilterSummary";
-import { act } from "react-dom/test-utils";
 
 describe("FilterSummary tests", () => {
-    let wrapper: RenderResult;
     const multipleQuestionnaires: string[] = ["LMS", "OPN"];
     const singleQuestionnaire: string[] = ["LMS"];
     const noQuestionnaires: string[] = [];
-    
-    beforeEach(async () =>{
-        await act(async () => {
-            wrapper = renderComponent(noQuestionnaires);
-        });
-    });
 
-    it("matches snapshot", async () => {
-        expect(await wrapper).toMatchSnapshot();
+    it("matches snapshot", () => {
+        expect(renderComponent(noQuestionnaires)).toMatchSnapshot();
     });
 
     describe("renders interviewer and period correctly", () => {
-        it("displays interviewer and the relevant information", () =>{
-            expect(wrapper.getByText(/Interviewer: Cal/)).toBeVisible();
+        it("displays interviewer and the relevant information", () => {
+            renderComponent(noQuestionnaires);
+            expect(screen.getByRole("heading", { name: /Interviewer: Cal/ })).toBeVisible();
         });
-        it("displays period and the relevant information", () =>{
-            expect(wrapper.getByText(/Period: 04\/05\/2022–05\/05\/2022/)).toBeVisible();
+
+        it("displays period and the relevant information", () => {
+            renderComponent(noQuestionnaires);
+            expect(screen.getByRole("heading", { name: /Period: 04\/05\/2022–05\/05\/2022/ })).toBeVisible();
         });
     });
 
     describe("renders correctly without questionnaires being filtered", () => {
-        it("does not display questionnaire when no questionnaires have been passed through", () =>{
-            expect(wrapper.queryByText(/Questionnaire/)).toBeNull();
+        it("does not display questionnaire when no questionnaires have been passed through", () => {
+            renderComponent(noQuestionnaires);
+            expect(screen.queryByText(/Questionnaire/)).not.toBeInTheDocument();
         });
     });
 
     describe("it renders correctly when questionnaires are filtered", () => {
-        it("displays one questionnaire and the relevant information", () =>{
-            wrapper = renderComponent(singleQuestionnaire);
-            expect(wrapper.getByText(/Questionnaire: LMS/)).toBeVisible();
+        it("displays one questionnaire and the relevant information", () => {
+            renderComponent(singleQuestionnaire);
+            expect(screen.getByRole("heading", { name: /Questionnaire: LMS/ })).toBeVisible();
         });
-        it("displays multiple questionnaires and the relevant information", () =>{
-            wrapper = renderComponent(multipleQuestionnaires);
-            expect(wrapper.getByText(/Questionnaires: LMS and OPN/)).toBeVisible();
+
+        it("displays multiple questionnaires and the relevant information", () => {
+            renderComponent(multipleQuestionnaires);
+            expect(screen.getByRole("heading", { name: /Questionnaires: LMS and OPN/ })).toBeVisible();
         });
     });
 });
 
-function renderComponent(questionnaires: string[]){
-    const history = createMemoryHistory();
+function renderComponent(questionnaires: string[]) {
     return render(
-        <Router history={history}>
-            <FilterSummary startDate={ new Date("2022-05-04") } endDate={ new Date("2022-05-05") } 
-                interviewer="Cal" questionnaires={questionnaires}/>
-        </Router>
+        <FilterSummary
+            startDate={ new Date("2022-05-04") }
+            endDate={ new Date("2022-05-05") }
+            interviewer="Cal"
+            questionnaires={ questionnaires }/>
     );
 }

--- a/src/components/FilterSummary.tsx
+++ b/src/components/FilterSummary.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, ReactNode } from "react";
 import { formatDate } from "../utilities/DateFormatter";
 
 interface FilterSummaryProps{
@@ -8,22 +8,18 @@ interface FilterSummaryProps{
     questionnaires: string[]
 }
 
-function FilterSummary(FilterSummaryProps: FilterSummaryProps): ReactElement {
-    if (FilterSummaryProps.questionnaires.length > 0) {
-        return (
-            <>
-                <h3 className="u-mb-m">
-                Interviewer: {FilterSummaryProps.interviewer} <br></br>
-                Period: {formatDate(FilterSummaryProps.startDate)}–{formatDate(FilterSummaryProps.endDate)}<br></br>
-                Questionnaire{FilterSummaryProps.questionnaires.length > 1 ? ("s") : ""}: {formatList(FilterSummaryProps.questionnaires)}
-                </h3>
-            </>
-        );
-    } return (
+function FilterSummary({ interviewer, startDate, endDate, questionnaires }: FilterSummaryProps): ReactElement {
+    let questionaires: ReactNode = null;
+    if (questionnaires.length > 0) {
+        const questionnaireHeading = `Questionnaire${ questionnaires.length > 1 ? "s" : "" }:`;
+        questionaires = <>{questionnaireHeading} {formatList(questionnaires)}</>;
+    }
+    return (
         <>
             <h3 className="u-mb-m">
-            Interviewer: {FilterSummaryProps.interviewer} <br></br>
-            Period: {formatDate(FilterSummaryProps.startDate)}–{formatDate(FilterSummaryProps.endDate)}<br></br>
+                Interviewer: {interviewer}<br/>
+                Period: {formatDate(startDate)}–{formatDate(endDate)}<br/>
+                {questionaires}
             </h3>
         </>
     );

--- a/src/components/__snapshots__/FilterSummary.test.tsx.snap
+++ b/src/components/__snapshots__/FilterSummary.test.tsx.snap
@@ -10,7 +10,6 @@ Object {
       >
         Interviewer: 
         Cal
-         
         <br />
         Period: 
         04/05/2022
@@ -26,7 +25,6 @@ Object {
     >
       Interviewer: 
       Cal
-       
       <br />
       Period: 
       04/05/2022

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -44,7 +44,7 @@ export type InterviewerCallHistoryReport = {
     wave?: string,
     questionnaire_id?: string,
     interviewer?: string,
-    outcome_code?: number,
+    outcome_code?: string,
     dial_number?: number,
     status?: string,
     survey?: string,

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import RenderInterviewerCallHistoryReport from "./RenderInterviewerCallHistoryReport";
-import { render, screen, within } from "@testing-library/react";
+import { render, RenderResult, screen, within } from "@testing-library/react";
 import { createMemoryHistory, History } from "history";
 import { Router } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
@@ -29,8 +29,8 @@ describe("RenderInterviewerCallHistoryReport", () => {
             .reply(200, { "last_updated": "Tue, 04 Oct 2022 00:00:06 GMT" });
     });
 
-    function renderComponent() {
-        render(
+    function renderComponent(): RenderResult {
+        return render(
             <Router history={ history }>
                 <RenderInterviewerCallHistoryReport
                     interviewer="rich"
@@ -62,7 +62,7 @@ describe("RenderInterviewerCallHistoryReport", () => {
             }
         ).reply(200, []);
         renderComponent();
-        await screen.findByText(/No/);
+        await screen.findByText(/No data found for parameters given/);
     });
 
     it("displays the call the last updated message", async () => {
@@ -99,6 +99,12 @@ describe("RenderInterviewerCallHistoryReport", () => {
         expect(screen.getByRole("heading", { name: /Interviewer:\s*rich/ })).toBeVisible();
         expect(screen.getByRole("heading", { name: /Period:\s*18\/09\/2022\s*–\s*17\/10\/2022/ })).toBeVisible();
         expect(screen.getByRole("heading", { name: /Questionnaires:\s*LMS1111 and LMS2222/ })).toBeVisible();
+    });
+
+    it("displays spinners while the status and report are loading", async () => {
+        renderComponent();
+        expect(screen.getAllByText("Loading")).toHaveLength(2);
+        await screen.findByText("Failed to load");
     });
 
     describe("when no results are found", () => {
@@ -150,7 +156,7 @@ describe("RenderInterviewerCallHistoryReport", () => {
             await screen.findByRole("columnheader", { name: "Questionnaire" });
         });
 
-        xit("displays the CVS link", () => {
+        it("displays the CVS link", () => {
             expect(screen.getByText(/Export report as Comma-Separated Values \(CSV\) file/)).toBeVisible();
         });
 

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
@@ -1,0 +1,193 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import RenderInterviewerCallHistoryReport from "./RenderInterviewerCallHistoryReport";
+import { render, screen, within } from "@testing-library/react";
+import { createMemoryHistory, History } from "history";
+import { Router } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { InterviewerCallHistoryReport } from "../../interfaces";
+
+const http = new MockAdapter(axios);
+
+describe("RenderInterviewerCallHistoryReport", () => {
+    let navigateBack: () => void;
+    let navigateBackTwoSteps: () => void;
+    let history: History<unknown>;
+
+    beforeEach(async () => {
+        http.reset();
+
+        history = createMemoryHistory();
+        history.push("/interviewer-call-history");
+
+        navigateBack = jest.fn();
+        navigateBackTwoSteps = jest.fn();
+
+        http.onGet("/api/reports/call-history-status")
+            .reply(200, { "last_updated": "Tue, 04 Oct 2022 00:00:06 GMT" });
+    });
+
+    function renderComponent() {
+        render(
+            <Router history={ history }>
+                <RenderInterviewerCallHistoryReport
+                    interviewer="rich"
+                    startDate={ new Date("September 18, 2022 01:23:00") }
+                    endDate={ new Date("October 17, 2022 04:56:00") }
+                    surveyTla="LMS"
+                    questionnaires={ ["LMS1111", "LMS2222"] }
+                    navigateBack={ navigateBack }
+                    navigateBackTwoSteps={ navigateBackTwoSteps }
+                />
+            </Router>
+        );
+    }
+
+    it("posts the search parameters to the backend", async () => {
+        expect.assertions(5);
+        http.onPost(
+            "/api/reports/interviewer-call-history",
+            {
+                // If these don't match then the tests fail with a 404
+                asymmetricMatch: (formData: FormData) => {
+                    expect(formData.get("survey_tla")).toBe("LMS");
+                    expect(formData.get("interviewer")).toBe("rich");
+                    expect(formData.get("start_date")).toBe("Sun Sep 18 2022 01:23:00 GMT+0100 (British Summer Time)");
+                    expect(formData.get("end_date")).toBe("Mon Oct 17 2022 04:56:00 GMT+0100 (British Summer Time)");
+                    expect(formData.get("questionnaires")).toBe("LMS1111,LMS2222");
+                    return true;
+                }
+            }
+        ).reply(200, []);
+        renderComponent();
+        await screen.findByText(/No/);
+    });
+
+    it("displays the call the last updated message", async () => {
+        renderComponent();
+        await screen.findByText(/Data in this report was last updated:/);
+        await screen.findByText(/\(04\/10\/2022 01:00:06\)/);
+    });
+
+    it("displays the header", () => {
+        renderComponent();
+        expect(screen.getByRole("heading", { name: "Call History Report" })).toBeVisible();
+    });
+
+    it("navigates to / when Reports is clicked", () => {
+        renderComponent();
+        userEvent.click(screen.getByRole("link", { name: "Reports" }));
+        expect(history.location.pathname).toBe("/");
+    });
+
+    it("calls navigateBackTwoSteps when Interview details is clicked", () => {
+        renderComponent();
+        userEvent.click(screen.getByRole("link", { name: "Interviewer details" }));
+        expect(navigateBackTwoSteps).toHaveBeenCalled();
+    });
+
+    it("calls navigateBack when Questionnaires is clicked", () => {
+        renderComponent();
+        userEvent.click(screen.getByRole("link", { name: "Questionnaires" }));
+        expect(navigateBack).toHaveBeenCalled();
+    });
+
+    it("displays the filter summary", () => {
+        renderComponent();
+        expect(screen.getByRole("heading", { name: /Interviewer:\s*rich/ })).toBeVisible();
+        expect(screen.getByRole("heading", { name: /Period:\s*18\/09\/2022\s*–\s*17\/10\/2022/ })).toBeVisible();
+        expect(screen.getByRole("heading", { name: /Questionnaires:\s*LMS1111 and LMS2222/ })).toBeVisible();
+    });
+
+    describe("when no results are found", () => {
+        beforeEach(async () => {
+            http.onPost("/api/reports/interviewer-call-history").reply(200, []);
+            renderComponent();
+        });
+
+        it("displays the not found message", async () => {
+            await screen.findByText("No data found for parameters given.");
+        });
+    });
+
+    xdescribe("when the server returned an error fetching report", () => {
+        beforeEach(async () => {
+            http.onPost("/api/reports/interviewer-call-history").reply(500, "");
+            renderComponent();
+        });
+
+        it("displays the not found message", async () => {
+            await screen.findByText("Failed to load");
+        });
+    });
+
+    xdescribe("when error occurred while fetching report", () => {
+        beforeEach(async () => {
+            http.onPost("/api/reports/interviewer-call-history").reply(() => {
+                throw new Error("Boom!");
+            });
+            renderComponent();
+        });
+
+        it("displays the not found message", async () => {
+            await screen.findByText("Failed to load");
+        });
+    });
+
+    describe("when results are loaded", () => {
+        beforeEach(async () => {
+            const results: InterviewerCallHistoryReport[] = [
+                {
+                    questionnaire_name: "LMS2202_TX9",
+                    serial_number: "101010",
+                    call_start_time: "Mon, 01 Aug 2022 01:02:03 GMT",
+                    dial_secs: 83,
+                    call_result: "Appointment"
+                },
+                {
+                    questionnaire_name: "DST2111Z",
+                    serial_number: "202020",
+                    call_start_time: "Thu, 06 Jan 2022 04:05:06 GMT",
+                    dial_secs: 3,
+                    call_result: "Busy"
+                },
+            ];
+            http.onPost("/api/reports/interviewer-call-history").reply(200, results);
+            renderComponent();
+            await screen.findByRole("columnheader", { name: "Questionnaire" });
+        });
+
+        xit("displays the CVS link", () => {
+            expect(screen.getByText(/Export report as Comma-Separated Values \(CSV\) file/)).toBeVisible();
+        });
+
+        it("displays table headings", () => {
+            const cells = screen.getAllByRole("columnheader");
+            expect(cells[0]).toHaveTextContent("Questionnaire");
+            expect(cells[1]).toHaveTextContent("Serial Number");
+            expect(cells[2]).toHaveTextContent("Call Start Time");
+            expect(cells[3]).toHaveTextContent("Call Length");
+            expect(cells[4]).toHaveTextContent("Call Result");
+        });
+
+        it("displays the calls", () => {
+            const rows = screen.getAllByRole("row");
+
+            const row1 = within(rows[1]).getAllByRole("cell");
+            expect(row1[0]).toHaveTextContent("LMS2202_TX9");
+            expect(row1[1]).toHaveTextContent("101010");
+            expect(row1[2]).toHaveTextContent("01/08/2022 02:02:03"); // BST adds an hour
+            expect(row1[3]).toHaveTextContent("01:23");
+            expect(row1[4]).toHaveTextContent("Appointment");
+
+            const row2 = within(rows[2]).getAllByRole("cell");
+            expect(row2[0]).toHaveTextContent("DST2111Z");
+            expect(row2[1]).toHaveTextContent("202020");
+            expect(row2[2]).toHaveTextContent("06/01/2022 04:05:06");
+            expect(row2[3]).toHaveTextContent("00:03");
+            expect(row2[4]).toHaveTextContent("Busy");
+        });
+    });
+});

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.test.tsx
@@ -102,36 +102,27 @@ describe("RenderInterviewerCallHistoryReport", () => {
     });
 
     describe("when no results are found", () => {
-        beforeEach(async () => {
+        it("displays the not found message", async () => {
             http.onPost("/api/reports/interviewer-call-history").reply(200, []);
             renderComponent();
-        });
-
-        it("displays the not found message", async () => {
             await screen.findByText("No data found for parameters given.");
         });
     });
 
-    xdescribe("when the server returned an error fetching report", () => {
-        beforeEach(async () => {
+    describe("when the server returned an error fetching report", () => {
+        it("displays the not found message", async () => {
             http.onPost("/api/reports/interviewer-call-history").reply(500, "");
             renderComponent();
-        });
-
-        it("displays the not found message", async () => {
             await screen.findByText("Failed to load");
         });
     });
 
-    xdescribe("when error occurred while fetching report", () => {
-        beforeEach(async () => {
+    describe("when error occurred while fetching report", () => {
+        it("displays the not found message", async () => {
             http.onPost("/api/reports/interviewer-call-history").reply(() => {
                 throw new Error("Boom!");
             });
             renderComponent();
-        });
-
-        it("displays the not found message", async () => {
             await screen.findByText("Failed to load");
         });
     });

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -1,27 +1,30 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, ReactNode, useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import { CSVLink } from "react-csv";
-import { ErrorBoundary } from "blaise-design-system-react-components";
 import { InterviewerCallHistoryReport } from "../../interfaces";
 import { getInterviewerCallHistoryReport } from "../../utilities/HTTP";
 import CallHistoryLastUpdatedStatus from "../../components/CallHistoryLastUpdatedStatus";
 import { formatDateAndTime } from "../../utilities/DateFormatter";
 import FilterSummary from "../../components/FilterSummary";
 import CallHistoryReportTable from "../../components/CallHistoryReportTable";
+import { ONSPanel } from "blaise-design-system-react-components";
 
 interface RenderInterviewerCallHistoryReportPageProps {
-    interviewer: string
-    startDate: Date
-    endDate: Date
-    surveyTla: string
-    questionnaires: string[]
-    navigateBack: () => void
-    navigateBackTwoSteps: () => void
+    interviewer: string;
+    startDate: Date;
+    endDate: Date;
+    surveyTla: string;
+    questionnaires: string[];
+    navigateBack: () => void;
+    navigateBackTwoSteps: () => void;
 }
+
+type ReportState = "loading" | "loaded" | "failed"
 
 function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryReportPageProps): ReactElement {
     const [reportData, setReportData] = useState<InterviewerCallHistoryReport[]>([]);
     const [interviewerID, setInterviewerID] = useState<string>("");
+    const [reportState, setReportState] = useState<ReportState>("loading");
     const {
         navigateBack,
         navigateBackTwoSteps,
@@ -37,9 +40,8 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
     ];
 
     useEffect(() => {
-        runInterviewerCallHistoryReport();
-    }, []
-    );
+        runInterviewerCallHistoryReport().catch(() => setReportState("failed"));
+    }, []);
 
     async function runInterviewerCallHistoryReport(): Promise<void> {
         const formValues: Record<string, any> = {};
@@ -51,46 +53,57 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
         formValues.end_date = props.endDate;
         formValues.questionnaires = props.questionnaires;
 
-        let callHistory: InterviewerCallHistoryReport[];
-        try {
-            callHistory = await getInterviewerCallHistoryReport(formValues);
-        } catch {
-            //setReportFailed(true);
-            return;
-        } finally {
-            //setSubmitting(false);
-        }
-
-        console.log(callHistory);
+        const callHistory = await getInterviewerCallHistoryReport(formValues);
         setReportData(callHistory);
+        console.log(callHistory);
+        setReportState("loaded");
+    }
+
+    function report(): ReactNode {
+        switch (reportState) {
+
+        case "loaded":
+            return (
+                <CallHistoryReportTable
+                    messageNoData="No data found for parameters given."
+                    reportData={ reportData }/>
+            );
+        case "failed":
+            return (
+                <ONSPanel status="error">
+                    <p>Failed to load</p>
+                </ONSPanel>
+            );
+        default:
+            return null;
+        }
     }
 
     return (
         <>
-            <Breadcrumbs BreadcrumbList={[{ link: "/", title: "Reports" }, {
+            <Breadcrumbs BreadcrumbList={ [{ link: "/", title: "Reports" }, {
                 link: "#",
                 onClickFunction: navigateBackTwoSteps,
                 title: "Interviewer details"
-            }, { link: "#", onClickFunction: navigateBack, title: "Questionnaires" }]}/>
+            }, { link: "#", onClickFunction: navigateBack, title: "Questionnaires" }] }/>
             <main id="main-content" className="page__main u-mt-s">
                 <h1>Call History Report</h1>
-                <FilterSummary {...props}/>
+                <FilterSummary { ...props }/>
                 <CallHistoryLastUpdatedStatus/>
                 <br/>
-                <CSVLink hidden={reportData === null || reportData.length === 0}
+                <CSVLink
+                    hidden={ reportData === null || reportData.length === 0 }
                     data={
                         reportData?.map(row => (
                             { ...row, call_start_time: formatDateAndTime(row.call_start_time) }
                         ))
                     }
-                    headers={reportExportHeaders}
+                    headers={ reportExportHeaders }
                     target="_blank"
-                    filename={`interviewer-call-history-${interviewerID}.csv`}>
+                    filename={ `interviewer-call-history-${ interviewerID }.csv` }>
                     Export report as Comma-Separated Values (CSV) file
                 </CSVLink>
-                <ErrorBoundary errorMessageText={"Failed to load"}>
-                    <CallHistoryReportTable messageNoData="No data found for parameters given." reportData={reportData}/>
-                </ErrorBoundary>
+                { report() }
             </main>
         </>
     );

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -84,11 +84,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
                 <h1>Call History Report</h1>
                 <FilterSummary {...props}/>
                 <CallHistoryLastUpdatedStatus/>
-
-                <div>
-
-                </div>
-
                 <br/>
                 <CSVLink hidden={reportData === null || reportData.length === 0}
                     data={

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -23,7 +23,6 @@ type ReportState = "loading" | "loaded" | "failed"
 
 function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryReportPageProps): ReactElement {
     const [reportData, setReportData] = useState<InterviewerCallHistoryReport[]>([]);
-    const [interviewerID, setInterviewerID] = useState<string>("");
     const [reportState, setReportState] = useState<ReportState>("loading");
     const {
         navigateBack,
@@ -46,7 +45,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
     async function runInterviewerCallHistoryReport(): Promise<void> {
         const formValues: Record<string, any> = {};
         setReportData([]);
-        setInterviewerID(props.interviewer);
         formValues.survey_tla = props.surveyTla;
         formValues.interviewer = props.interviewer;
         formValues.start_date = props.startDate;
@@ -100,7 +98,7 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
                     }
                     headers={ reportExportHeaders }
                     target="_blank"
-                    filename={ `interviewer-call-history-${ interviewerID }.csv` }>
+                    filename={ `interviewer-call-history-${ props.interviewer }.csv` }>
                     Export report as Comma-Separated Values (CSV) file
                 </CSVLink>
                 { report() }

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -70,7 +70,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
 
         console.log(callHistory);
         setReportData(callHistory);
-
     }
 
     return (
@@ -98,7 +97,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
                 </CSVLink>
                 <ErrorBoundary errorMessageText={"Failed to load"}>
                     <CallHistoryReportTable messageNoData={messageNoData} reportData={reportData}/>
-                    <br/>
                 </ErrorBoundary>
             </main>
         </>

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -22,7 +22,6 @@ interface RenderInterviewerCallHistoryReportPageProps {
 function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryReportPageProps): ReactElement {
     const [reportData, setReportData] = useState<InterviewerCallHistoryReport[]>([]);
     const [interviewerID, setInterviewerID] = useState<string>("");
-    const [messageNoData, setMessageNoData] = useState<string>("");
     const {
         navigateBack,
         navigateBackTwoSteps,
@@ -44,7 +43,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
 
     async function runInterviewerCallHistoryReport(): Promise<void> {
         const formValues: Record<string, any> = {};
-        setMessageNoData("");
         setReportData([]);
         setInterviewerID(props.interviewer);
         formValues.survey_tla = props.surveyTla;
@@ -61,11 +59,6 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
             return;
         } finally {
             //setSubmitting(false);
-        }
-
-        if (callHistory.length === 0) {
-            setMessageNoData("No data found for parameters given.");
-            return;
         }
 
         console.log(callHistory);
@@ -96,7 +89,7 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
                     Export report as Comma-Separated Values (CSV) file
                 </CSVLink>
                 <ErrorBoundary errorMessageText={"Failed to load"}>
-                    <CallHistoryReportTable messageNoData={messageNoData} reportData={reportData}/>
+                    <CallHistoryReportTable messageNoData="No data found for parameters given." reportData={reportData}/>
                 </ErrorBoundary>
             </main>
         </>

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -7,7 +7,7 @@ import CallHistoryLastUpdatedStatus from "../../components/CallHistoryLastUpdate
 import { formatDateAndTime } from "../../utilities/DateFormatter";
 import FilterSummary from "../../components/FilterSummary";
 import CallHistoryReportTable from "../../components/CallHistoryReportTable";
-import { ONSPanel } from "blaise-design-system-react-components";
+import { ONSPanel, ONSLoadingPanel } from "blaise-design-system-react-components";
 
 interface RenderInterviewerCallHistoryReportPageProps {
     interviewer: string;
@@ -75,7 +75,7 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
                 </ONSPanel>
             );
         default:
-            return null;
+            return <ONSLoadingPanel/>;
         }
     }
 

--- a/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
+++ b/src/reports/InterviewerCallHistory/RenderInterviewerCallHistoryReport.tsx
@@ -81,11 +81,11 @@ function RenderInterviewerCallHistoryReport(props: RenderInterviewerCallHistoryR
 
     return (
         <>
-            <Breadcrumbs BreadcrumbList={ [{ link: "/", title: "Reports" }, {
-                link: "#",
-                onClickFunction: navigateBackTwoSteps,
-                title: "Interviewer details"
-            }, { link: "#", onClickFunction: navigateBack, title: "Questionnaires" }] }/>
+            <Breadcrumbs BreadcrumbList={ [
+                { link: "/", title: "Reports" },
+                { link: "#", onClickFunction: navigateBackTwoSteps, title: "Interviewer details" },
+                { link: "#", onClickFunction: navigateBack, title: "Questionnaires" }
+            ] }/>
             <main id="main-content" className="page__main u-mt-s">
                 <h1>Call History Report</h1>
                 <FilterSummary { ...props }/>

--- a/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
+++ b/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
@@ -92,16 +92,14 @@ Object {
         >
           Interviewer: 
           thorne1
-           
           <br />
           Period: 
           31/01/2023
           –
           31/01/2024
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           foo
         </h3>
         <p
@@ -647,16 +645,14 @@ Object {
       >
         Interviewer: 
         thorne1
-         
         <br />
         Period: 
         31/01/2023
         –
         31/01/2024
         <br />
-        Questionnaire
-        
-        : 
+        Questionnaire:
+         
         foo
       </h3>
       <p
@@ -1259,16 +1255,14 @@ Object {
         >
           Interviewer: 
           thorne1
-           
           <br />
           Period: 
           31/01/2023
           –
           31/01/2024
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           foo
         </h3>
         <p
@@ -1798,16 +1792,14 @@ Object {
       >
         Interviewer: 
         thorne1
-         
         <br />
         Period: 
         31/01/2023
         –
         31/01/2024
         <br />
-        Questionnaire
-        
-        : 
+        Questionnaire:
+         
         foo
       </h3>
       <p
@@ -2394,16 +2386,14 @@ Object {
         >
           Interviewer: 
           thorne1
-           
           <br />
           Period: 
           31/01/2023
           –
           31/01/2024
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           foo
         </h3>
         <p
@@ -2569,16 +2559,14 @@ Object {
       >
         Interviewer: 
         thorne1
-         
         <br />
         Period: 
         31/01/2023
         –
         31/01/2024
         <br />
-        Questionnaire
-        
-        : 
+        Questionnaire:
+         
         foo
       </h3>
       <p
@@ -2801,16 +2789,14 @@ Object {
         >
           Interviewer: 
           thorne1
-           
           <br />
           Period: 
           31/01/2023
           –
           31/01/2024
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           foo
         </h3>
         <p
@@ -2963,16 +2949,14 @@ Object {
       >
         Interviewer: 
         thorne1
-         
         <br />
         Period: 
         31/01/2023
         –
         31/01/2024
         <br />
-        Questionnaire
-        
-        : 
+        Questionnaire:
+         
         foo
       </h3>
       <p

--- a/src/reports/filters/__snapshots__/QuestionnaireFilter.test.tsx.snap
+++ b/src/reports/filters/__snapshots__/QuestionnaireFilter.test.tsx.snap
@@ -71,16 +71,14 @@ Object {
           >
             Interviewer: 
             James
-             
             <br />
             Period: 
             01/01/2022
             –
             05/01/2022
             <br />
-            Questionnaire
-            
-            : 
+            Questionnaire:
+             
             LMS2101_AA1
           </h3>
           <p
@@ -265,16 +263,14 @@ Object {
         >
           Interviewer: 
           James
-           
           <br />
           Period: 
           01/01/2022
           –
           05/01/2022
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           LMS2101_AA1
         </h3>
         <p
@@ -516,16 +512,14 @@ Object {
           >
             Interviewer: 
             James
-             
             <br />
             Period: 
             01/01/2022
             –
             05/01/2022
             <br />
-            Questionnaire
-            
-            : 
+            Questionnaire:
+             
             LMS2101_AA1
           </h3>
           <p
@@ -723,16 +717,14 @@ Object {
         >
           Interviewer: 
           James
-           
           <br />
           Period: 
           01/01/2022
           –
           05/01/2022
           <br />
-          Questionnaire
-          
-          : 
+          Questionnaire:
+           
           LMS2101_AA1
         </h3>
         <p

--- a/src/utilities/HTTP/Reports.test.ts
+++ b/src/utilities/HTTP/Reports.test.ts
@@ -83,6 +83,7 @@ describe("getInterviewerCallHistoryReport", () => {
         serial_number: "9001",
         call_start_time: "2022-01-02 10:05:20",
         dial_secs: 50,
+        outcome_code: "310",
     };
 
     afterEach(() => {


### PR DESCRIPTION
- fix: Remove unnecessary div
- test: Include outcome_code in test
- test: Use screen in tests
- refactor: Tidy FilterSummary
- fix: Use index for key
- test: Add tests for RenderInterviewerCallHistoryReport
- refactor: Remove unnecessary state
