### PR TITLE
BLAIS5-3409: Fix error handling in interviewer call pattern report

### DIFF
--- a/src/components/LoadData.test.tsx
+++ b/src/components/LoadData.test.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { DataRenderer, LoadData } from "./LoadData";
 import { screen } from "@testing-library/dom";
 
@@ -79,6 +79,17 @@ describe("LoadData", () => {
                 >{ display }</LoadData>
             );
             expect(await screen.findByText("HTML ERROR: There was an error")).toBeVisible();
+        });
+
+        it("displays turns off the error message if given false", async () => {
+            render(
+                <LoadData
+                    dataPromise={ Promise.reject("There was an error") }
+                    errorMessage={ false }
+                >{ display }</LoadData>
+            );
+            await waitFor(() => { expect(screen.queryByText("Loading")).not.toBeInTheDocument(); });
+            expect(screen.queryByText("There was an error")).not.toBeInTheDocument();
         });
 
         it("does not display the loading spinner", async () => {

--- a/src/components/LoadData.test.tsx
+++ b/src/components/LoadData.test.tsx
@@ -90,6 +90,18 @@ describe("LoadData", () => {
             await screen.findByText("There was an error");
             expect(screen.queryByText("Loading")).not.toBeInTheDocument();
         });
+
+        it("calls onError", async () => {
+            const onError = jest.fn();
+            render(
+                <LoadData
+                    dataPromise={ Promise.reject("There was an error") }
+                    onError={onError}
+                >{ display }</LoadData>
+            );
+            await screen.findByText("There was an error");
+            expect(onError).toHaveBeenCalledWith("There was an error");
+        });
     });
 
     describe("dataPromise props changing", () => {

--- a/src/components/LoadData.tsx
+++ b/src/components/LoadData.tsx
@@ -5,7 +5,7 @@ export type DataRenderer<T> = (data: T) => ReactNode
 
 interface LoaderProps<T> {
     dataPromise: Promise<T>;
-    errorMessage?: string | ((error: Error) => ReactNode);
+    errorMessage?: string | false | ((error: Error) => ReactNode);
     onError?: (error: Error) => void;
     children: DataRenderer<T>;
 }
@@ -47,6 +47,11 @@ export function LoadData<T>({ children, dataPromise, errorMessage, onError }: Lo
             return errorMessage;
         }
 
+        if (errorMessage === false)
+        {
+            return null;
+        }
+
         if (errorMessage !== undefined) {
             return errorMessage(error);
         }
@@ -60,6 +65,10 @@ export function LoadData<T>({ children, dataPromise, errorMessage, onError }: Lo
         }
 
         if (loadState instanceof ErroredState) {
+            if (errorMessage === false) {
+                return null;
+            }
+
             return (
                 <ONSPanel status="error">
                     <p>{ getErrorMessage(loadState.error) }</p>

--- a/src/components/LoadData.tsx
+++ b/src/components/LoadData.tsx
@@ -25,19 +25,21 @@ type LoadState<T> = LoadingState | LoadedState<T> | ErroredState
 export function LoadData<T>({ children, dataPromise, errorMessage, onError }: LoaderProps<T>): ReactElement {
     const [loadState, setLoadState] = useState<LoadState<T>>(new LoadingState());
 
+    async function loadData() {
+        setLoadState(new LoadedState(await dataPromise));
+    }
+
+    function setErroredState(error: Error): void {
+        if (onError) {
+            onError(error);
+        }
+        setLoadState(new ErroredState(error));
+    }
+
     useEffect(() => {
         setLoadState(new LoadingState());
 
-        async function loadData() {
-            setLoadState(new LoadedState(await dataPromise));
-        }
-
-        loadData().catch((error) => {
-            setLoadState(new ErroredState(error));
-            if (onError) {
-                onError(error);
-            }
-        });
+        loadData().catch(setErroredState);
     }, [dataPromise]);
 
     function getErrorMessage(error: Error): ReactNode {

--- a/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
+++ b/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
@@ -563,7 +563,7 @@ describe("function InterviewerCallPattern() with request error", () => {
             </Router>
         );
 
-        await screen.findByText("Error: Request failed");
+        await screen.findByRole("heading", { name: "Failed to run the report" });
 
         expect(await wrapper).toMatchSnapshot();
     });
@@ -587,8 +587,9 @@ describe("function InterviewerCallPattern() with request error", () => {
             );
         });
 
-        await screen.findByText("Error: Request failed");
         await screen.findByRole("heading", { name: "Failed to run the report" });
+
+        expect(screen.queryByText("Error: Request failed")).not.toBeInTheDocument();
 
         expect(screen.queryByText("Reports")).toBeVisible();
         expect(screen.getByText("Interviewer details")).toBeVisible();
@@ -606,4 +607,3 @@ describe("function InterviewerCallPattern() with request error", () => {
         expect(screen.queryByText("Invalid Fields")).not.toBeInTheDocument();
     });
 });
-

--- a/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
+++ b/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
@@ -201,10 +201,6 @@ describe("function InterviewerCallPattern() with happy data", () => {
             </Router>
         );
 
-        await act(async () => {
-            await flushPromises();
-        });
-
         await screen.findByText("Questionnaires");
 
         expect(await wrapper).toMatchSnapshot();
@@ -225,10 +221,6 @@ describe("function InterviewerCallPattern() with happy data", () => {
                 />
             </Router>
         );
-
-        await act(async () => {
-            await flushPromises();
-        });
 
         expect(await screen.findByText("Reports")).toBeVisible();
         expect(screen.getByText("Interviewer details")).toBeVisible();
@@ -314,10 +306,6 @@ describe("function InterviewerCallPattern() with data and invalid data", () => {
                 />
             </Router>
         );
-
-        await act(async () => {
-            await flushPromises();
-        });
 
         await screen.findByText("Questionnaires");
 
@@ -432,10 +420,6 @@ describe("function InterviewerCallPattern() without data", () => {
             </Router>
         );
 
-        await act(async () => {
-            await flushPromises();
-        });
-
         await screen.findByText("Questionnaires");
 
         expect(await wrapper).toMatchSnapshot();
@@ -500,10 +484,6 @@ describe("function InterviewerCallPattern() with only invalid data", () => {
                 />
             </Router>
         );
-
-        await act(async () => {
-            await flushPromises();
-        });
 
         expect(await screen.findByText("Reports")).toBeVisible();
 

--- a/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
+++ b/src/reports/InterviewerCallPattern/InterviewerCallPattern.test.tsx
@@ -588,6 +588,7 @@ describe("function InterviewerCallPattern() with request error", () => {
         });
 
         await screen.findByText("Error: Request failed");
+        await screen.findByRole("heading", { name: "Failed to run the report" });
 
         expect(screen.queryByText("Reports")).toBeVisible();
         expect(screen.getByText("Interviewer details")).toBeVisible();

--- a/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
+++ b/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
@@ -229,7 +229,7 @@ function RenderInterviewerCallPatternReport({
                 <LoadData
                     dataPromise={ runInterviewerCallPatternReport() }
                     onError={() => setReportFailed(true) }
-                    errorMessage={() => <></>}>{ displayReport }</LoadData>
+                    errorMessage={ false }>{ displayReport }</LoadData>
                 <br/>
             </main>
         </>

--- a/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
+++ b/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
@@ -228,7 +228,8 @@ function RenderInterviewerCallPatternReport({
                 <br/>
                 <LoadData
                     dataPromise={ runInterviewerCallPatternReport() }
-                    onError={() => setReportFailed(true) }>{ displayReport }</LoadData>
+                    onError={() => setReportFailed(true) }
+                    errorMessage={() => <></>}>{ displayReport }</LoadData>
                 <br/>
             </main>
         </>

--- a/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
+++ b/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
@@ -155,7 +155,7 @@ function RenderInterviewerCallPatternReport({
     navigateBack,
     navigateBackTwoSteps,
 }: RenderInterviewerCallPatternReportPageProps): ReactElement {
-    const [reportFailed] = useState<boolean>(false);
+    const [reportFailed, setReportFailed] = useState<boolean>(false);
 
     async function runInterviewerCallPatternReport(): Promise<[SummaryState, GroupedSummary, Group]> {
         const formValues: Record<string, any> = {};
@@ -226,7 +226,9 @@ function RenderInterviewerCallPatternReport({
                     </ONSPanel>
                 </div>
                 <br/>
-                <LoadData dataPromise={ runInterviewerCallPatternReport() }>{ displayReport }</LoadData>
+                <LoadData
+                    dataPromise={ runInterviewerCallPatternReport() }
+                    onError={() => setReportFailed(true) }>{ displayReport }</LoadData>
                 <br/>
             </main>
         </>

--- a/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
+++ b/src/reports/InterviewerCallPattern/RenderInterviewerCallPatternReport.tsx
@@ -144,7 +144,7 @@ function ReportData(
     );
 }
 
-type SummaryState = "load_failed" | "no_data" | "all_invalid_fields" | "loaded"
+type SummaryState = "no_data" | "all_invalid_fields" | "loaded"
 
 function RenderInterviewerCallPatternReport({
     surveyTla,
@@ -165,25 +165,20 @@ function RenderInterviewerCallPatternReport({
         formValues.end_date = endDate;
         formValues.questionnaires = questionnaires;
 
-        try {
-            const callHistory: InterviewerCallPatternReport | undefined = await getInterviewerCallPatternReport(formValues);
+        const callHistory: InterviewerCallPatternReport | undefined = await getInterviewerCallPatternReport(formValues);
 
-            if (callHistory === undefined) {
-                return ["no_data", new GroupedSummary([]), { title: "", records: {} }];
-            }
-
-            callHistory.total_records = callHistory.discounted_invalid_cases
-                + (callHistory.total_valid_cases || 0);
-
-            if (isAllInvalid(callHistory)) {
-                return ["all_invalid_fields", new GroupedSummary([]), invalidFieldsGroup(callHistory)];
-            }
-
-            return ["loaded", groupData(callHistory), invalidFieldsGroup(callHistory)];
-        } catch {
-            return ["load_failed", new GroupedSummary([]), { title: "", records: {} }];
+        if (callHistory === undefined) {
+            return ["no_data", new GroupedSummary([]), { title: "", records: {} }];
         }
 
+        callHistory.total_records = callHistory.discounted_invalid_cases
+            + (callHistory.total_valid_cases || 0);
+
+        if (isAllInvalid(callHistory)) {
+            return ["all_invalid_fields", new GroupedSummary([]), invalidFieldsGroup(callHistory)];
+        }
+
+        return ["loaded", groupData(callHistory), invalidFieldsGroup(callHistory)];
     }
 
     const displayReport = useCallback(

--- a/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
+++ b/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
@@ -2789,6 +2789,381 @@ Object {
 }
 `;
 
+exports[`function InterviewerCallPattern() with request error should match the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <nav
+        aria-label="Breadcrumb"
+        class="breadcrumb"
+      >
+        <ol
+          class="breadcrumb__items u-fs-s"
+        >
+          <li
+            class="breadcrumb__item"
+            id="breadcrumb-0"
+          >
+            <a
+              class="breadcrumb__link"
+              href="/"
+            >
+              Reports
+            </a>
+            <svg
+              class="svg-icon"
+              focusable="false"
+              viewBox="0 0 8 13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+                transform="translate(-5.02 -1.59)"
+              />
+            </svg>
+          </li>
+          <li
+            class="breadcrumb__item"
+            id="breadcrumb-1"
+          >
+            <a
+              class="breadcrumb__link"
+              href="/"
+            >
+              Interviewer details
+            </a>
+            <svg
+              class="svg-icon"
+              focusable="false"
+              viewBox="0 0 8 13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+                transform="translate(-5.02 -1.59)"
+              />
+            </svg>
+          </li>
+          <li
+            class="breadcrumb__item"
+            id="breadcrumb-2"
+          >
+            <a
+              class="breadcrumb__link"
+              href="/"
+            >
+              Questionnaires
+            </a>
+            <svg
+              class="svg-icon"
+              focusable="false"
+              viewBox="0 0 8 13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+                transform="translate(-5.02 -1.59)"
+              />
+            </svg>
+          </li>
+        </ol>
+      </nav>
+      <main
+        class="page__main u-mt-s"
+        id="main-content"
+      >
+        <h1>
+          Call Pattern Report
+        </h1>
+        <h3
+          class="u-mb-m"
+        >
+          Interviewer: 
+          thorne1
+          <br />
+          Period: 
+          31/01/2023
+          –
+          31/01/2024
+          <br />
+          Questionnaire:
+           
+          foo
+        </h3>
+        <p
+          aria-live="polite"
+          class="u-fs-s u-mt-s"
+        >
+          Data in this report was last updated: 
+          <b>
+            <time
+              datetime="2000-01-01T10:00:00.000Z"
+              title="2000-01-01 10:00"
+            >
+              2 days ago
+            </time>
+             (01/01/2000 10:00:00)
+          </b>
+        </p>
+        <p
+          class="u-fs-s"
+        >
+          Data in this report only goes back to the last 12 months.
+        </p>
+        <div
+          class="u-mb-m"
+        >
+          <div
+            class="panel panel--info panel--no-title  u-mt-m"
+          >
+            <div
+              class="panel__body "
+            >
+              <p>
+                Incomplete data is removed from this report. This will impact the accuracy of the report.
+              </p>
+              <p>
+                The 
+                <b>
+                  Discounted invalid records
+                </b>
+                 entry will advise how many records have been removed.
+              </p>
+              <p>
+                Information will be displayed at the top of the report to advise which fields were incomplete.
+              </p>
+            </div>
+          </div>
+        </div>
+        <br />
+        <div
+          class="panel panel--error panel--no-title  u-mt-m"
+        >
+          <div
+            class="panel__body "
+          >
+            <p>
+              Error: Request failed
+            </p>
+          </div>
+        </div>
+        <br />
+      </main>
+    </div>
+  </body>,
+  "container": <div>
+    <nav
+      aria-label="Breadcrumb"
+      class="breadcrumb"
+    >
+      <ol
+        class="breadcrumb__items u-fs-s"
+      >
+        <li
+          class="breadcrumb__item"
+          id="breadcrumb-0"
+        >
+          <a
+            class="breadcrumb__link"
+            href="/"
+          >
+            Reports
+          </a>
+          <svg
+            class="svg-icon"
+            focusable="false"
+            viewBox="0 0 8 13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+              transform="translate(-5.02 -1.59)"
+            />
+          </svg>
+        </li>
+        <li
+          class="breadcrumb__item"
+          id="breadcrumb-1"
+        >
+          <a
+            class="breadcrumb__link"
+            href="/"
+          >
+            Interviewer details
+          </a>
+          <svg
+            class="svg-icon"
+            focusable="false"
+            viewBox="0 0 8 13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+              transform="translate(-5.02 -1.59)"
+            />
+          </svg>
+        </li>
+        <li
+          class="breadcrumb__item"
+          id="breadcrumb-2"
+        >
+          <a
+            class="breadcrumb__link"
+            href="/"
+          >
+            Questionnaires
+          </a>
+          <svg
+            class="svg-icon"
+            focusable="false"
+            viewBox="0 0 8 13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+              transform="translate(-5.02 -1.59)"
+            />
+          </svg>
+        </li>
+      </ol>
+    </nav>
+    <main
+      class="page__main u-mt-s"
+      id="main-content"
+    >
+      <h1>
+        Call Pattern Report
+      </h1>
+      <h3
+        class="u-mb-m"
+      >
+        Interviewer: 
+        thorne1
+        <br />
+        Period: 
+        31/01/2023
+        –
+        31/01/2024
+        <br />
+        Questionnaire:
+         
+        foo
+      </h3>
+      <p
+        aria-live="polite"
+        class="u-fs-s u-mt-s"
+      >
+        Data in this report was last updated: 
+        <b>
+          <time
+            datetime="2000-01-01T10:00:00.000Z"
+            title="2000-01-01 10:00"
+          >
+            2 days ago
+          </time>
+           (01/01/2000 10:00:00)
+        </b>
+      </p>
+      <p
+        class="u-fs-s"
+      >
+        Data in this report only goes back to the last 12 months.
+      </p>
+      <div
+        class="u-mb-m"
+      >
+        <div
+          class="panel panel--info panel--no-title  u-mt-m"
+        >
+          <div
+            class="panel__body "
+          >
+            <p>
+              Incomplete data is removed from this report. This will impact the accuracy of the report.
+            </p>
+            <p>
+              The 
+              <b>
+                Discounted invalid records
+              </b>
+               entry will advise how many records have been removed.
+            </p>
+            <p>
+              Information will be displayed at the top of the report to advise which fields were incomplete.
+            </p>
+          </div>
+        </div>
+      </div>
+      <br />
+      <div
+        class="panel panel--error panel--no-title  u-mt-m"
+      >
+        <div
+          class="panel__body "
+        >
+          <p>
+            Error: Request failed
+          </p>
+        </div>
+      </div>
+      <br />
+    </main>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`function InterviewerCallPattern() without data should match the snapshot 1`] = `
 Object {
   "asFragment": [Function],

--- a/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
+++ b/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
@@ -2971,9 +2971,7 @@ Object {
           <div
             class="panel__body "
           >
-            <p>
-              Error: Request failed
-            </p>
+            <p />
           </div>
         </div>
         <br />
@@ -3158,9 +3156,7 @@ Object {
         <div
           class="panel__body "
         >
-          <p>
-            Error: Request failed
-          </p>
+          <p />
         </div>
       </div>
       <br />

--- a/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
+++ b/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
@@ -2891,6 +2891,34 @@ Object {
            
           foo
         </h3>
+        <div
+          role="alert"
+          tabindex="-1"
+        >
+          <div
+            class="panel panel--error panel--no-title  u-mt-m"
+          >
+            <div
+              class="panel__body "
+            >
+              <h2>
+                Failed to run the report
+              </h2>
+              <p>
+                Try again later.
+              </p>
+              <p>
+                If you are still experiencing problems 
+                <a
+                  href="https://ons.service-now.com/"
+                >
+                  report this issue
+                </a>
+                 to Service Desk
+              </p>
+            </div>
+          </div>
+        </div>
         <p
           aria-live="polite"
           class="u-fs-s u-mt-s"
@@ -3050,6 +3078,34 @@ Object {
          
         foo
       </h3>
+      <div
+        role="alert"
+        tabindex="-1"
+      >
+        <div
+          class="panel panel--error panel--no-title  u-mt-m"
+        >
+          <div
+            class="panel__body "
+          >
+            <h2>
+              Failed to run the report
+            </h2>
+            <p>
+              Try again later.
+            </p>
+            <p>
+              If you are still experiencing problems 
+              <a
+                href="https://ons.service-now.com/"
+              >
+                report this issue
+              </a>
+               to Service Desk
+            </p>
+          </div>
+        </div>
+      </div>
       <p
         aria-live="polite"
         class="u-fs-s u-mt-s"

--- a/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
+++ b/src/reports/InterviewerCallPattern/__snapshots__/InterviewerCallPattern.test.tsx.snap
@@ -2965,15 +2965,6 @@ Object {
           </div>
         </div>
         <br />
-        <div
-          class="panel panel--error panel--no-title  u-mt-m"
-        >
-          <div
-            class="panel__body "
-          >
-            <p />
-          </div>
-        </div>
         <br />
       </main>
     </div>
@@ -3150,15 +3141,6 @@ Object {
         </div>
       </div>
       <br />
-      <div
-        class="panel panel--error panel--no-title  u-mt-m"
-      >
-        <div
-          class="panel__body "
-        >
-          <p />
-        </div>
-      </div>
       <br />
     </main>
   </div>,


### PR DESCRIPTION
- test: Remove unneeded flushPromises
- fix: Display error message on failure
- feat: Add onError to LoadData
- feat: Show custom error message
- feat: Remove standard error
